### PR TITLE
Указание либы lodash (lodash-es) в явном виде как зависимость

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@types/lodash": "^4.14.168",
     "eventemitter3": "^4.0.7",
+    "lodash-es": "^4.17.21",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
@@ -52,6 +52,7 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
+    "@types/lodash-es": "^4.17.12",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",

--- a/src/lib/case.ts
+++ b/src/lib/case.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import camelCase from 'lodash/camelCase'
-import snakeCase from 'lodash/snakeCase'
+import { camelCase, snakeCase } from 'lodash-es'
 
 export const isUuid = (value: string) => {
   return /[0-9a-fA-F-]{32}/.test(value)

--- a/yarn.lock
+++ b/yarn.lock
@@ -688,10 +688,17 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/lodash@^4.14.168":
-  version "4.14.195"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.195.tgz#bafc975b252eb6cea78882ce8a7b6bf22a6de632"
-  integrity sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==
+"@types/lodash-es@^4.17.12":
+  version "4.17.12"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.12.tgz#65f6d1e5f80539aa7cfbfc962de5def0cf4f341b"
+  integrity sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.202"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.202.tgz#f09dbd2fb082d507178b2f2a5c7e74bd72ff98f8"
+  integrity sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==
 
 "@types/minimist@^1.2.0":
   version "1.2.2"
@@ -3693,6 +3700,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
### Проблема

- Сейчас `lodash` используется в исходниках как либа, но при этом она не добавлена в список зависимостей явным образом:

<details>
  <summary>(cкриншот)</summary>

![image](https://github.com/ExpressApp/smartapp-bridge/assets/5501615/15d0c664-48ed-4698-bd56-c2e47fe544eb)

</details>

- Это влечёт за собой предупреждение во время сборки `smartapp-sdk` от сборщика, о том что эта зависимость помечена как внешняя, и будет импортироваться во время рантайма из области видимости:

<details>
  <summary>(cкриншот)</summary>

![image](https://github.com/ExpressApp/smartapp-bridge/assets/5501615/9906d863-d64f-4913-85cb-2293e52f075a)


</details>

- Также, в текущем билде bridge и sdk присутствует лишний служебный код от сборщика:

<details>
  <summary>(cкриншот)</summary>

![image](https://github.com/ExpressApp/smartapp-bridge/assets/5501615/36db7676-a749-494e-9836-058b7f5232f3)

</details>


### Что было сделано
- Удален пакет `"@types/lodash": "^4.14.168"` из dependencies, тк это devDependencies
- Отсутствующая либа `lodash` заменена на `lodash-es` (одно и то же, но по разному экспортируется).
Тип подключения через ES-модули уменьшает размер бандла.
Подробнее тут:
https://www.npmjs.com/package/lodash-es
https://itnext.io/lodash-es-vs-individual-lodash-utilities-size-comparison-676f14b07568
https://til.hashrocket.com/posts/dnzttruljf-prefer-lodash-es-when-using-webpack
- Обновлён импорт в исходниках с `lodash` на `lodash-es`
- Добавлен пакет `"@types/lodash-es": "^4.17.12",` в devDependencies